### PR TITLE
fixed prog_name did not catch the whole name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Fixed
+
+- The :prog_name: configuration did not catched the whole phrase (stopped at whitespace). (Pull #44)
+
 ## 0.4.0 - 2021-05-12
 
 ### Added

--- a/mkdocs_click/_processing.py
+++ b/mkdocs_click/_processing.py
@@ -22,7 +22,7 @@ def replace_blocks(lines: Iterable[str], title: str, replace: Callable[..., Iter
 
     for line in lines:
         if in_block_section:
-            match = re.search(r"^\s+:(?P<key>.+):(?:\s+(?P<value>\S+))?", line)
+            match = re.search(r"^\s+:(?P<key>.+):(?:\s+(?P<value>.+))?", line)
             if match is not None:
                 # New ':key:' or ':key: value' line, ingest it.
                 key = match.group("key")


### PR DESCRIPTION
fixes: https://github.com/DataDog/mkdocs-click/issues/42

The regex that parses the mkdocs configuration did not catch the whole phrase of the value.
