### PR TITLE
Allow options to contain multiple words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Fixed
+
+- `:prog_name:` and other options can now contain multiple words (it used to stop at whitespace). (Pull #60)
+
 ## 0.8.0 - 2022-06-19
 
 ### Added

--- a/mkdocs_click/_processing.py
+++ b/mkdocs_click/_processing.py
@@ -22,7 +22,7 @@ def replace_blocks(lines: Iterable[str], title: str, replace: Callable[..., Iter
 
     for line in lines:
         if in_block_section:
-            match = re.search(r"^\s+:(?P<key>.+):(?:\s+(?P<value>\S+))?", line)
+            match = re.search(r"^\s+:(?P<key>.+):(?:\s+(?P<value>.*\S))?", line)
             if match is not None:
                 # New ':key:' or ':key: value' line, ingest it.
                 key = match.group("key")

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -12,16 +12,17 @@ def test_replace_options():
 foo
 ::: target
     :option1: value1
-    :optiøn2: value2
+    :optiøn2: val ue2
 \t:option3:
     :option4:\x20
+    :option5: 1
 bar
 """.strip()
 
     expected = """
 # Some content
 foo
-{'option1': 'value1', 'optiøn2': 'value2', 'option3': '', 'option4': ''}
+{'option1': 'value1', 'optiøn2': 'val ue2', 'option3': '', 'option4': '', 'option5': '1'}
 bar
 """.strip()
 


### PR DESCRIPTION
This PR is based on and supersedes the one in #44. I added more explanation, a test, and fixed a small bug with trailing whitespace.

--- 

When documenting subcommands, sometimes mkdocs-click will only show the
subcommand name. `:prog_name:` seems to be the right option to ensure
the actuall command is shown, but due to an overly-strict regex, it
used to ignore everything after the first whitespace. With this change,
`prog_name` and other commands can contain multiple words in their
values.

For example

```
::: mkdocs-click
    :module: foo.utils.bridge
    :prog_name: foo-utils bridge
    :command: cli
```

now properly renders as

> foo-utils bridge [OPTIONS]

instead of

> foo-utils [OPTIONS]

or

> bridge [OPTIONS]

(^^ if prog_name wasn't specified at all)

Co-Authored-By: Bar Hochman <bhochman@paloaltonetworks.com>

* Fixes #42
* Closes #44