### PR TITLE
Add the code blocks as ```text to avoid highlighting

### DIFF
--- a/mkdocs_click/_docs.py
+++ b/mkdocs_click/_docs.py
@@ -189,7 +189,7 @@ def _make_usage(ctx: click.Context) -> Iterator[str]:
 
     yield "**Usage:**"
     yield ""
-    yield "```"
+    yield "```text"
     yield usage
     yield "```"
     yield ""
@@ -240,7 +240,7 @@ def _make_plain_options(ctx: click.Context, show_hidden: bool = False) -> Iterat
 
         yield "**Options:**"
         yield ""
-        yield "```"
+        yield "```text"
         yield from option_lines
         yield "```"
         yield ""

--- a/tests/app/expected-enhanced.md
+++ b/tests/app/expected-enhanced.md
@@ -4,13 +4,13 @@ Main entrypoint for this dummy program
 
 **Usage:**
 
-```
+```text
 cli [OPTIONS] COMMAND [ARGS]...
 ```
 
 **Options:**
 
-```
+```text
   --help  Show this message and exit.
 ```
 
@@ -20,13 +20,13 @@ The bar command
 
 **Usage:**
 
-```
+```text
 cli bar [OPTIONS] COMMAND [ARGS]...
 ```
 
 **Options:**
 
-```
+```text
   --help  Show this message and exit.
 ```
 
@@ -36,13 +36,13 @@ Simple program that greets NAME for a total of COUNT times.
 
 **Usage:**
 
-```
+```text
 cli bar hello [OPTIONS]
 ```
 
 **Options:**
 
-```
+```text
   --count INTEGER  Number of greetings.
   --name TEXT      The person to greet.
   --help           Show this message and exit.
@@ -52,12 +52,12 @@ cli bar hello [OPTIONS]
 
 **Usage:**
 
-```
+```text
 cli foo [OPTIONS]
 ```
 
 **Options:**
 
-```
+```text
   --help  Show this message and exit.
 ```

--- a/tests/app/expected-sub-enhanced.md
+++ b/tests/app/expected-sub-enhanced.md
@@ -4,13 +4,13 @@ Main entrypoint for this dummy program
 
 **Usage:**
 
-```
+```text
 cli [OPTIONS] COMMAND [ARGS]...
 ```
 
 **Options:**
 
-```
+```text
   --help  Show this message and exit.
 ```
 
@@ -25,13 +25,13 @@ The bar command
 
 **Usage:**
 
-```
+```text
 cli bar [OPTIONS] COMMAND [ARGS]...
 ```
 
 **Options:**
 
-```
+```text
   --help  Show this message and exit.
 ```
 
@@ -45,13 +45,13 @@ Simple program that greets NAME for a total of COUNT times.
 
 **Usage:**
 
-```
+```text
 cli bar hello [OPTIONS]
 ```
 
 **Options:**
 
-```
+```text
   --count INTEGER  Number of greetings.
   --name TEXT      The person to greet.
   --help           Show this message and exit.
@@ -61,12 +61,12 @@ cli bar hello [OPTIONS]
 
 **Usage:**
 
-```
+```text
 cli foo [OPTIONS]
 ```
 
 **Options:**
 
-```
+```text
   --help  Show this message and exit.
 ```

--- a/tests/app/expected-sub.md
+++ b/tests/app/expected-sub.md
@@ -4,13 +4,13 @@ Main entrypoint for this dummy program
 
 **Usage:**
 
-```
+```text
 cli [OPTIONS] COMMAND [ARGS]...
 ```
 
 **Options:**
 
-```
+```text
   --help  Show this message and exit.
 ```
 
@@ -25,13 +25,13 @@ The bar command
 
 **Usage:**
 
-```
+```text
 cli bar [OPTIONS] COMMAND [ARGS]...
 ```
 
 **Options:**
 
-```
+```text
   --help  Show this message and exit.
 ```
 
@@ -45,13 +45,13 @@ Simple program that greets NAME for a total of COUNT times.
 
 **Usage:**
 
-```
+```text
 cli bar hello [OPTIONS]
 ```
 
 **Options:**
 
-```
+```text
   --count INTEGER  Number of greetings.
   --name TEXT      The person to greet.
   --help           Show this message and exit.
@@ -61,12 +61,12 @@ cli bar hello [OPTIONS]
 
 **Usage:**
 
-```
+```text
 cli foo [OPTIONS]
 ```
 
 **Options:**
 
-```
+```text
   --help  Show this message and exit.
 ```

--- a/tests/app/expected.md
+++ b/tests/app/expected.md
@@ -4,13 +4,13 @@ Main entrypoint for this dummy program
 
 **Usage:**
 
-```
+```text
 cli [OPTIONS] COMMAND [ARGS]...
 ```
 
 **Options:**
 
-```
+```text
   --help  Show this message and exit.
 ```
 
@@ -20,13 +20,13 @@ The bar command
 
 **Usage:**
 
-```
+```text
 cli bar [OPTIONS] COMMAND [ARGS]...
 ```
 
 **Options:**
 
-```
+```text
   --help  Show this message and exit.
 ```
 
@@ -36,13 +36,13 @@ Simple program that greets NAME for a total of COUNT times.
 
 **Usage:**
 
-```
+```text
 cli bar hello [OPTIONS]
 ```
 
 **Options:**
 
-```
+```text
   --count INTEGER  Number of greetings.
   --name TEXT      The person to greet.
   --help           Show this message and exit.
@@ -52,12 +52,12 @@ cli bar hello [OPTIONS]
 
 **Usage:**
 
-```
+```text
 cli foo [OPTIONS]
 ```
 
 **Options:**
 
-```
+```text
   --help  Show this message and exit.
 ```

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -50,13 +50,13 @@ HELLO_EXPECTED = dedent(
 
     **Usage:**
 
-    ```
+    ```text
     hello [OPTIONS]
     ```
 
     **Options:**
 
-    ```
+    ```text
       -d, --debug TEXT  Include debug output
       --help            Show this message and exit.
     ```
@@ -116,7 +116,7 @@ HELLO_FULL_TABLE_EXPECTED = dedent(
 
     **Usage:**
 
-    ```
+    ```text
     hello [OPTIONS]
     ```
 
@@ -149,7 +149,7 @@ HELLO_MINIMAL_TABLE_EXPECTED = dedent(
 
     **Usage:**
 
-    ```
+    ```text
     hello [OPTIONS]
     ```
 
@@ -201,13 +201,13 @@ def test_custom_multicommand(multi):
 
         **Usage:**
 
-        ```
+        ```text
         multi [OPTIONS] COMMAND [ARGS]...
         ```
 
         **Options:**
 
-        ```
+        ```text
           --help  Show this message and exit.
         ```
 
@@ -217,13 +217,13 @@ def test_custom_multicommand(multi):
 
         **Usage:**
 
-        ```
+        ```text
         multi hello [OPTIONS]
         ```
 
         **Options:**
 
-        ```
+        ```text
           -d, --debug TEXT  Include debug output
           --help            Show this message and exit.
         ```
@@ -253,13 +253,13 @@ def test_custom_multicommand_with_list_subcommands(multi):
 
         **Usage:**
 
-        ```
+        ```text
         multi [OPTIONS] COMMAND [ARGS]...
         ```
 
         **Options:**
 
-        ```
+        ```text
           --help  Show this message and exit.
         ```
 
@@ -273,13 +273,13 @@ def test_custom_multicommand_with_list_subcommands(multi):
 
         **Usage:**
 
-        ```
+        ```text
         multi hello [OPTIONS]
         ```
 
         **Options:**
 
-        ```
+        ```text
           -d, --debug TEXT  Include debug output
           --help            Show this message and exit.
         ```


### PR DESCRIPTION
This ensures the code block isn't highlighted even with highlight.js

Before/after comparison on "mkdocs" theme:

![before-after](https://user-images.githubusercontent.com/371383/194671593-de9ecfa3-98d1-406d-ba14-7cace6b455ef.gif)
