### PR TITLE
pass command.context_settings to new context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Remove explicit reference to `click.BaseCommand` and `click.MultiCommand` objects in anticipation of their deprecation. (Pull #82)
 - Properly ensure whitespace is trimmed from the usage string. (Pull #83)
+- Propagate `context_settings` to `click.Context`-like objects. (Pull #79)
 
 ## 0.8.1 - 2023-09-18
 

--- a/mkdocs_click/_docs.py
+++ b/mkdocs_click/_docs.py
@@ -92,8 +92,12 @@ def _recursively_make_command_docs(
 def _build_command_context(
     prog_name: str, command: click.Command, parent: click.Context | None
 ) -> click.Context:
-    return _get_context_class(command)(
-        cast(click.Command, command), info_name=prog_name, parent=parent
+    # https://github.com/pallets/click/blob/8.1.8/src/click/core.py#L859-L862
+    return command.context_class(command)(
+        cast(click.Command, command),
+        info_name=prog_name,
+        parent=parent,
+        **command.context_settings,
     )
 
 
@@ -366,11 +370,6 @@ def _make_subcommands_links(
             help_string = "*No description was provided with this command.*"
         yield f"- *{command_bullet}*: {help_string}"
     yield ""
-
-
-def _get_context_class(command: click.Command) -> type[click.Context]:
-    # https://github.com/pallets/click/blob/8.1.8/src/click/core.py#L859-L862
-    return command.context_class
 
 
 def _is_command_group(command: click.Command) -> bool:

--- a/mkdocs_click/_docs.py
+++ b/mkdocs_click/_docs.py
@@ -93,7 +93,7 @@ def _build_command_context(
     prog_name: str, command: click.Command, parent: click.Context | None
 ) -> click.Context:
     # https://github.com/pallets/click/blob/8.1.8/src/click/core.py#L859-L862
-    return command.context_class(command)(
+    return command.context_class(
         cast(click.Command, command),
         info_name=prog_name,
         parent=parent,


### PR DESCRIPTION
When creating a context from the command, the context settings were not propagated, which means that some options set on the command would be ignored.

To illustrate:

```py
import click
@click.command(context_settings={"help_option_names": ["-h", "--help"], "show_default": True})
@click.option("-t", "--test", type=int, default=42)
def cli(test):
    print("the number is", test)
```

Now compare `ctx.get_help()` when the context is and is not passed through:

```py
>>> ctx = click.Context(cli)
>>> print(ctx.get_help())
Usage:  [OPTIONS]

Options:
  -t, --test INTEGER
  --help              Show this message and exit.
>>> ctx = click.Context(cli, **cli.context_settings)
>>> print(ctx.get_help())
Usage:  [OPTIONS]

Options:
  -t, --test INTEGER  [default: 42]
  -h, --help          Show this message and exit.
```

You'll see the additional `-h` short flag for help, and the default argument for `-t` which wasn't shown before.

With this fix, these settings are now respected through `:style: plain` so that the output matches what is shown at the command line after building with `mkdocs`.