### PR TITLE
Full command path headers: add note regarding md extensions order

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ markdown_extensions:
     - mkdocs-click
 ```
 
-Note: mind the order, `attr_list` should be above `mkdocs-click`, otherwise the feature does not work.
+***IMPORTANT:*** `attr_list` must come before `mkdocs-click` for this to work.
 
 `mkdocs-click` will then output the full command path in headers (e.g. `## cli build all`) and permalinks (e.g. `#cli-build-all`).
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ markdown_extensions:
     - mkdocs-click
 ```
 
+Note: mind the order, `attr_list` should be above `mkdocs-click`, otherwise the feature does not work.
+
 `mkdocs-click` will then output the full command path in headers (e.g. `## cli build all`) and permalinks (e.g. `#cli-build-all`).
 
 Note that the table of content (TOC) will still use the command name: the TOC is naturally hierarchal, so full command paths would be redundant. (This exception is why the `attr_list` extension is required.)


### PR DESCRIPTION
I could not have it working since I had them in wrong order
I could not find a way to have both orders working by changing the code